### PR TITLE
fix: allow node CI to run without CODECOV_TOKEN

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     secrets:
       CODECOV_TOKEN:
-        required: true
+        required: false
 
 jobs:
   build:
@@ -35,3 +35,4 @@ jobs:
       with:
         name: ${{ runner.os }} node.js ${{ matrix.node-version }}
         token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false


### PR DESCRIPTION
## Description

If a repo doesn't add `secrets: inherit` when using this workflow, they'll get the following error and their node CI tests won't run: 

```
Invalid workflow file: .github/workflows/node.js.yml#L14
The workflow is not valid. .github/workflows/node.js.yml (Line: 14, Col: 11): Secret CODECOV_TOKEN is required, but not provided while calling.
```

This PR proposes not requiring the CODECOV_TOKEN secret and also not failing CI if codecov upload fails, so tests can still run while we update all our repos to inherit secrets

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.