### PR TITLE
update: skip codecov upload on Dependabot PRs, add admin comment triggered re-upload

### DIFF
--- a/.github/workflows/dependabot-coverage-upload.yml
+++ b/.github/workflows/dependabot-coverage-upload.yml
@@ -1,0 +1,74 @@
+name: Dependabot Coverage Upload
+
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: dependabot-coverage-${{ github.repository }}-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Get PR head SHA
+        id: pr
+        run: |
+          set -euo pipefail
+          SHA=$(gh api repos/$GITHUB_REPOSITORY/pulls/$ISSUE_NUMBER --jq '.head.sha')
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+      - name: Find original CI run
+        id: run
+        run: |
+          set -euo pipefail
+          RUN_ID=$(gh api "repos/$GITHUB_REPOSITORY/actions/artifacts?per_page=100" \
+            --jq "[.artifacts[] | select(.name | startswith(\"coverage-report-\")) | select(.workflow_run.head_sha == \"$HEAD_SHA\")] | first | .workflow_run.id")
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "run_id=" >> $GITHUB_OUTPUT
+          else
+            echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.pr.outputs.sha }}
+
+      - name: Download coverage artifacts
+        if: steps.run.outputs.run_id != ''
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-report-*
+          run-id: ${{ steps.run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Upload to Codecov
+        if: steps.download.outcome == 'success'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: '**/lcov.info'
+          fail_ci_if_error: false
+
+      - name: Comment — success
+        if: steps.download.outcome == 'success'
+        run: gh pr comment $ISSUE_NUMBER --edit-last --body "Coverage uploaded to Codecov successfully."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+      - name: Comment — artifact missing
+        if: steps.run.outputs.run_id == '' || steps.download.outcome == 'failure'
+        run: gh pr comment $ISSUE_NUMBER --edit-last --body "Coverage artifact not found. Re-run CI first, then comment \`/upload-coverage\` again."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/dependabot-coverage-upload.yml
+++ b/.github/workflows/dependabot-coverage-upload.yml
@@ -61,14 +61,14 @@ jobs:
 
       - name: Comment — success
         if: steps.download.outcome == 'success'
-        run: gh pr comment $ISSUE_NUMBER --edit-last --body "Coverage uploaded to Codecov successfully."
+        run: gh pr comment $ISSUE_NUMBER --repo $GITHUB_REPOSITORY --edit-last --body "Coverage uploaded to Codecov successfully."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
 
       - name: Comment — artifact missing
         if: steps.run.outputs.run_id == '' || steps.download.outcome == 'failure'
-        run: gh pr comment $ISSUE_NUMBER --edit-last --body "Coverage artifact not found. Re-run CI first, then comment \`/upload-coverage\` again."
+        run: gh pr comment $ISSUE_NUMBER --repo $GITHUB_REPOSITORY --edit-last --body "Coverage artifact not found. Re-run CI first, then comment \`/upload-coverage\` again."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/dependabot-coverage-upload.yml
+++ b/.github/workflows/dependabot-coverage-upload.yml
@@ -61,14 +61,14 @@ jobs:
 
       - name: Comment — success
         if: steps.download.outcome == 'success'
-        run: gh pr comment $ISSUE_NUMBER --repo $GITHUB_REPOSITORY --edit-last --body "Coverage uploaded to Codecov successfully."
+        run: gh pr comment $ISSUE_NUMBER --repo $GITHUB_REPOSITORY --edit-last --body "Coverage uploaded to Codecov successfully." 2>/dev/null || gh pr comment $ISSUE_NUMBER --repo $GITHUB_REPOSITORY --body "Coverage uploaded to Codecov successfully."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
 
       - name: Comment — artifact missing
         if: steps.run.outputs.run_id == '' || steps.download.outcome == 'failure'
-        run: gh pr comment $ISSUE_NUMBER --repo $GITHUB_REPOSITORY --edit-last --body "Coverage artifact not found. Re-run CI first, then comment \`/upload-coverage\` again."
+        run: gh pr comment $ISSUE_NUMBER --repo $GITHUB_REPOSITORY --edit-last --body "Coverage artifact not found. Re-run CI first, then comment \`/upload-coverage\` again." 2>/dev/null || gh pr comment $ISSUE_NUMBER --repo $GITHUB_REPOSITORY --body "Coverage artifact not found. Re-run CI first, then comment \`/upload-coverage\` again."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,9 +30,16 @@ jobs:
     - run: npm run build --if-present
     - run: npm test
     - name: upload coverage
-      if: success()
+      if: success() && github.actor != 'dependabot[bot]'
       uses: codecov/codecov-action@v4
       with:
         name: ${{ runner.os }} node.js ${{ matrix.node-version }}
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
+    - name: save coverage artifact
+      if: github.actor == 'dependabot[bot]'
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report-${{ matrix.os }}-${{ matrix.node-version }}
+        path: coverage/lcov.info
+        if-no-files-found: warn


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Skip the Codecov upload step for Dependabot PRs and save all matrix coverage artifacts instead. Adds a reusable workflow that allows repo admins to upload coverage to Codecov by commenting /upload-coverage on the Dependabot PR.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/ACNA-4537
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
GitHub restricts secret access on Dependabot PRs for security reasons, making CODECOV_TOKEN unavailable. The upload step was silently failing. This fix preserves coverage reporting for Dependabot PRs without compromising the secret restriction model.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.