### PR TITLE
fix: checkout PR head, ubuntu-only artifacts, override PR/commit for Codecov

### DIFF
--- a/.github/workflows/dependabot-coverage-upload.yml
+++ b/.github/workflows/dependabot-coverage-upload.yml
@@ -14,6 +14,7 @@ jobs:
       cancel-in-progress: true
     permissions:
       actions: read
+      contents: read
       pull-requests: write
     steps:
       - name: Get PR head SHA
@@ -26,12 +27,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
 
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+
       - name: Find original CI run
         id: run
         run: |
           set -euo pipefail
+          # per_page=100 covers all recent artifacts; sorted newest-first by default
           RUN_ID=$(gh api "repos/$GITHUB_REPOSITORY/actions/artifacts?per_page=100" \
-            --jq "[.artifacts[] | select(.name | startswith(\"coverage-report-\")) | select(.workflow_run.head_sha == \"$HEAD_SHA\")] | first | .workflow_run.id")
+            --jq "[.artifacts[] | select(.name | startswith(\"coverage-report-ubuntu-latest-\")) | select(.workflow_run.head_sha == \"$HEAD_SHA\")] | first | .workflow_run.id")
           if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
             echo "run_id=" >> $GITHUB_OUTPUT
           else
@@ -46,7 +53,7 @@ jobs:
         id: download
         uses: actions/download-artifact@v4
         with:
-          pattern: coverage-report-*
+          pattern: coverage-report-ubuntu-latest-*
           run-id: ${{ steps.run.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
@@ -57,6 +64,8 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: '**/lcov.info'
+          override_pr: ${{ github.event.issue.number }}
+          override_commit: ${{ steps.pr.outputs.sha }}
           fail_ci_if_error: false
 
       - name: Comment — success


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixes the reusable `dependabot-coverage-upload.yml` workflow so Codecov correctly processes coverage reports uploaded via the `/upload-coverage` admin comment trigger on Dependabot PRs. Previously every upload was marked "Unusable report".

Three root causes fixed:
1. Missing `actions/checkout`: Codecov embeds a local file listing in the upload payload to map `SF:` paths in lcov; without source files present the report is always unusable
2. Artifact pattern included Windows runs — Windows lcov uses backslash paths (`SF:src\auth.js`) that Codecov cannot resolve against the repo; narrowed to `ubuntu-latest` only
3. Missing `override_pr` / `override_commit` — Codecov was not associating the upload with the correct Dependabot PR

Also aligns the `startswith()` filter in "Find original CI run" with the download pattern to prevent false "artifact not found" comments.

## Related Issue
[ACNA-4537](https://jira.corp.adobe.com/browse/ACNA-4537)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When Dependabot opens a PR, GitHub restricts secret access so `CODECOV_TOKEN` is unavailable and the normal upload in `node.js.yml` is skipped. Coverage artifacts are saved instead, and an admin triggers re-upload via `/upload-coverage` comment. This PR makes that re-upload actually work.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested end-to-end on `adobe/aio-e2e-tests` using the `dependabot-codecov-fix` branch (which `aio-e2e-tests` calls):
- Commented `/upload-coverage` as an admin on a Dependabot PR
- Confirmed Codecov successfully processed the report (no "Unusable report", coverage % shown)
- Confirmed Codecov posted a coverage comment on the PR


## Screenshots (if appropriate):
https://github.com/adobe/aio-e2e-tests/pull/193
<img width="3352" height="2076" alt="image" src="https://github.com/user-attachments/assets/c6df52c1-1c26-4c03-9497-74f6f3884bff" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.